### PR TITLE
feature/resiliency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ pre_build:
 	mkdir -p ./bin
 
 build_local_image:
-	docker build .
+	docker build . -t mannemsolutions/pgarrow
 
 build_arrow:
 	go build -o ./bin/arrow.$(uname_p) ./cmd/arrow

--- a/config/pgarrow.yml
+++ b/config/pgarrow.yml
@@ -9,6 +9,6 @@ pg_config:
     user: postgres
     host: postgres
   skip_errors:
-    144645: duplicate key value violates unique constraint
+    23505: duplicate key value violates unique constraint
 rabbit_config:
   url: amqp://arrow:arrow@rabbit:5672/

--- a/config/pgarrow.yml
+++ b/config/pgarrow.yml
@@ -8,5 +8,7 @@ pg_config:
     password: pgarrow
     user: postgres
     host: postgres
+  skip_errors:
+    144645: duplicate key value violates unique constraint
 rabbit_config:
   url: amqp://arrow:arrow@rabbit:5672/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,13 @@ services:
     volumes:
     - ./:/host
     - ./config/postgresql.conf:/etc/postgresql/postgresql.conf
-#  zookeeper:
-#    image: 'bitnami/zookeeper:latest'
-#    ports:
-#      - '2181:2181'
-#    environment:
-#      ALLOW_ANONYMOUS_LOGIN: yes
+  zookeeper:
+    image: 'bitnami/zookeeper:latest'
+    platform: linux/amd64
+    ports:
+      - '2181:2181'
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: yes
 #    networks:
 #      - app-tier
   kafka:
@@ -33,19 +34,20 @@ services:
       - '9092:9092'
     environment:
       ALLOW_PLAINTEXT_LISTENER: 'yes'
-      KAFKA_ENABLE_KRAFT: 'yes'
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-#     KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
-      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_BROKER_ID: 1
-#      KAFKA_INTER_BROKER_LISTENER_NAME: CLIENT
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
-#     KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-#    depends_on:
-#      - zookeeper
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: true
+      #KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      #KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+      #KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+      #KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      #KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+      #KAFKA_ENABLE_KRAFT: 'yes'
+      #KAFKA_INTER_BROKER_LISTENER_NAME: CLIENT
+    depends_on:
+      - zookeeper
   pgarrowkafka:
     environment:
       PGDATABASE: src

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -73,7 +73,7 @@ func (c *Config) NewTopic(name string) *Topic {
 
 	t := Topic{
 		name:   fmt.Sprintf("%s_%s", c.Prefix, name),
-		parent: c,
+		config: c,
 	}
 	c.topics[name] = &t
 

--- a/pkg/kafka/topic.go
+++ b/pkg/kafka/topic.go
@@ -50,6 +50,14 @@ func (t *Topic) MustClose() {
 }
 
 func (t *Topic) Close() (err error) {
+	if err = t.CloseReader(); err != nil {
+		return err
+	} else {
+		return t.CloseWriter()
+	}
+}
+
+func (t *Topic) CloseReader() (err error) {
 	if t.reader == nil {
 		return nil
 	}
@@ -57,6 +65,17 @@ func (t *Topic) Close() (err error) {
 		return err
 	}
 	t.reader = nil
+	return nil
+}
+
+func (t *Topic) CloseWriter() (err error) {
+	if t.writer == nil {
+		return nil
+	}
+	if err = t.writer.Close(); err != nil {
+		return err
+	}
+	t.writer = nil
 	return nil
 }
 

--- a/pkg/pg/column_value.go
+++ b/pkg/pg/column_value.go
@@ -21,7 +21,7 @@ func ColValsFromLogMsg(cols []*pglogrepl.TupleDataColumn, relInfo *pglogrepl.Rel
 		case 't': //text
 			val, err := decodeTextColumnData(col.Data, relInfo.Columns[idx].DataType)
 			if err != nil {
-				log.Fatalln("error decoding column data:", err)
+				log.Fatal("error decoding column data:", err)
 			}
 
 			switch v := val.(type) {

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -3,9 +3,10 @@ package pg
 import "time"
 
 type Config struct {
-	DSN                   Dsn           `yaml:"dsn"`
-	Slot                  string        `yaml:"slot_name"`
-	standbyMessageTimeout time.Duration `yaml:"standby_message_timeout"`
+	DSN                   Dsn              `yaml:"dsn"`
+	Slot                  string           `yaml:"slot_name"`
+	SkipErrors            map[int64]string `yaml:"skip_errors"`
+	StandbyMessageTimeout time.Duration    `yaml:"standby_message_timeout"`
 }
 
 // Initialize currently has no function, but can be used to initialize teh config with defaults

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -3,10 +3,10 @@ package pg
 import "time"
 
 type Config struct {
-	DSN                   Dsn              `yaml:"dsn"`
-	Slot                  string           `yaml:"slot_name"`
-	SkipErrors            map[int64]string `yaml:"skip_errors"`
-	StandbyMessageTimeout time.Duration    `yaml:"standby_message_timeout"`
+	DSN                   Dsn               `yaml:"dsn"`
+	Slot                  string            `yaml:"slot_name"`
+	SkipErrors            map[string]string `yaml:"skip_errors"`
+	StandbyMessageTimeout time.Duration     `yaml:"standby_message_timeout"`
 }
 
 // Initialize currently has no function, but can be used to initialize teh config with defaults

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -17,8 +17,8 @@ func (c *Config) Initialize() (err error) {
 	if c.Slot == "" {
 		c.Slot = "pgarrow"
 	}
-	if c.standbyMessageTimeout.Milliseconds() < 1 {
-		c.standbyMessageTimeout = time.Second * 10
+	if c.StandbyMessageTimeout.Milliseconds() < 1 {
+		c.StandbyMessageTimeout = time.Second * 10
 	}
 	return nil
 }
@@ -27,7 +27,7 @@ func (c Config) Clone() (newConfig Config) {
 	newConfig = Config{
 		DSN:                   c.DSN.Clone(),
 		Slot:                  c.Slot,
-		standbyMessageTimeout: c.standbyMessageTimeout,
+		StandbyMessageTimeout: c.StandbyMessageTimeout,
 	}
 	if err := newConfig.Initialize(); err != nil {
 		log.Fatalf("failed to initialize this config: %e", err)

--- a/pkg/pg/conn.go
+++ b/pkg/pg/conn.go
@@ -13,17 +13,19 @@ import (
 type RelationMessages map[uint32]*pglogrepl.RelationMessage
 
 type Conn struct {
-	config           *Config
-	rConn            *pgconn.PgConn
-	qConn            *pgconn.PgConn
-	relationMessages RelationMessages
-	XLogPos          pglogrepl.LSN
+	config                      *Config
+	rConn                       *pgconn.PgConn
+	qConn                       *pgconn.PgConn
+	relationMessages            RelationMessages
+	XLogPos                     pglogrepl.LSN
+	lastPrimaryKeepaliveMessage time.Time
 }
 
 func NewConn(conf *Config) (c *Conn) {
 	return &Conn{
-		config:           conf,
-		relationMessages: make(RelationMessages),
+		config:                      conf,
+		relationMessages:            make(RelationMessages),
+		lastPrimaryKeepaliveMessage: time.Now(),
 	}
 }
 

--- a/pkg/pg/conn.go
+++ b/pkg/pg/conn.go
@@ -225,16 +225,14 @@ func (c *Conn) ProcessMsg(msg []byte) (err error) {
 		log.Debugf("succesfully ran %s", sql)
 	} else if pgErr, ok := err.(*pgconn.PgError); !ok {
 		return err
-	} else if pgErrCode, err := strconv.ParseInt(pgErr.Code, 16, 32); err != nil {
-		log.Fatalf("unexpected SQLSTATE %s", pgErr.Code)
-	} else if description, exists := c.config.SkipErrors[pgErrCode]; exists {
-		log.Debugf("skipping error code %d (%s)", pgErrCode, description)
+	} else if description, exists := c.config.SkipErrors[pgErr.Code]; exists {
+		log.Debugf("skipping error code %s (%s)", pgErr.Code, description)
 		return nil
 	} else {
 		log.Error(pgErr)
 		log.Debug("to skip, add this to pg_config.skip_errors:")
-		log.Debugf(" -> %d: \"%s\"",
-			pgErrCode, strings.Replace(pgErr.Message, "\"", "'", -1))
+		log.Debugf(" -> \"%s\": \"%s\"",
+			pgErr.Code, strings.Replace(pgErr.Message, "\"", "'", -1))
 		return pgErr
 	}
 	return nil

--- a/pkg/pg/conn.go
+++ b/pkg/pg/conn.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -39,10 +40,14 @@ func (c *Conn) Connect() (err error) {
 			return nil
 		}
 	}
-	c.rConn, err = pgconn.Connect(ctx, c.config.DSN.ConnString(true))
-	if err != nil {
-		c.rConn = nil
-		return err
+	for {
+		c.rConn, err = pgconn.Connect(ctx, c.config.DSN.ConnString(true))
+		if err == nil {
+			break
+		}
+		log.Errorln("Cannot connect to Postgres:", err.Error())
+		log.Infof("Retrying in 10 seconds")
+		time.Sleep(10 * time.Second)
 	}
 
 	return nil

--- a/pkg/pg/conn.go
+++ b/pkg/pg/conn.go
@@ -206,7 +206,7 @@ func (c *Conn) GetTableFromOID(oid uint32) (t Table, err error) {
 	return t, nil
 }
 
-func (c Conn) ProcessMsg(msg []byte) (err error) {
+func (c *Conn) ProcessMsg(msg []byte) (err error) {
 	log.Debug("Processing messages")
 	log.Debugf("Processing msg (%d bytes)", len(msg))
 	var t Transaction

--- a/pkg/pg/repl.go
+++ b/pkg/pg/repl.go
@@ -16,6 +16,10 @@ import (
 )
 
 func (c *Conn) StartRepl() (err error) {
+	if c.rConn != nil {
+		log.Debugln("rConn already initialized. Assuming we are already replicating")
+		return nil
+	}
 	if err = c.Connect(); err != nil {
 		return err
 	}
@@ -68,7 +72,7 @@ func (c *Conn) NextTransactions() (t Transaction, err error) {
 			if err != nil {
 				log.Fatal("SendStandbyStatusUpdate failed:", err)
 			}
-			log.Debug("Sent Standby status message")
+			//log.Debug("Sent Standby status message")
 			nextStandbyMessageDeadline = time.Now().Add(standbyMessageTimeout)
 		}
 

--- a/pkg/pg/repl.go
+++ b/pkg/pg/repl.go
@@ -52,7 +52,7 @@ func (c *Conn) StartRepl() (err error) {
 
 // NextTransactions reads the next transaction and returns. For TRUNCATE this could be more than one.
 func (c *Conn) NextTransactions() (t Transaction, err error) {
-	standbyMessageTimeout := c.config.standbyMessageTimeout
+	standbyMessageTimeout := c.config.StandbyMessageTimeout
 	nextStandbyMessageDeadline := time.Now().Add(standbyMessageTimeout)
 
 	var (

--- a/pkg/pg/repl.go
+++ b/pkg/pg/repl.go
@@ -104,10 +104,14 @@ func (c *Conn) NextTransactions() (t Transaction, err error) {
 			if err != nil {
 				log.Fatal("ParsePrimaryKeepaliveMessage failed:", err)
 			}
-			log.Debug("Primary Keepalive Message =>", "ServerWALEnd:",
-				pkm.ServerWALEnd, "ServerTime:",
-				pkm.ServerTime, "ReplyRequested:",
-				pkm.ReplyRequested)
+			// This makes sure that the debug log is not flooded when Postgres stops
+			if time.Now().Sub(c.lastPrimaryKeepaliveMessage) > time.Second {
+				log.Debugln("Primary Keepalive Message =>",
+					"ServerWALEnd:", pkm.ServerWALEnd,
+					"ServerTime:", pkm.ServerTime,
+					"ReplyRequested:", pkm.ReplyRequested)
+				c.lastPrimaryKeepaliveMessage = time.Now()
+			}
 
 			if pkm.ReplyRequested {
 				nextStandbyMessageDeadline = time.Time{}

--- a/pkg/pg/repl.go
+++ b/pkg/pg/repl.go
@@ -44,7 +44,7 @@ func (c *Conn) StartRepl() (err error) {
 		pglogrepl.StartReplicationOptions{
 			PluginArgs: []string{"proto_version '1'", "publication_names 'pgarrow'"}})
 	if err != nil {
-		log.Fatalln("StartReplication failed:", err)
+		log.Fatal("StartReplication failed:", err)
 	}
 	log.Info("Logical replication started on slot", c.config.Slot)
 	return nil
@@ -66,7 +66,7 @@ func (c *Conn) NextTransactions() (t Transaction, err error) {
 		if time.Now().After(nextStandbyMessageDeadline) {
 			err = pglogrepl.SendStandbyStatusUpdate(context.Background(), c.rConn, pglogrepl.StandbyStatusUpdate{WALWritePosition: c.XLogPos})
 			if err != nil {
-				log.Fatalln("SendStandbyStatusUpdate failed:", err)
+				log.Fatal("SendStandbyStatusUpdate failed:", err)
 			}
 			log.Debug("Sent Standby status message")
 			nextStandbyMessageDeadline = time.Now().Add(standbyMessageTimeout)
@@ -98,7 +98,7 @@ func (c *Conn) NextTransactions() (t Transaction, err error) {
 		case pglogrepl.PrimaryKeepaliveMessageByteID:
 			pkm, err = pglogrepl.ParsePrimaryKeepaliveMessage(msg.Data[1:])
 			if err != nil {
-				log.Fatalln("ParsePrimaryKeepaliveMessage failed:", err)
+				log.Fatal("ParsePrimaryKeepaliveMessage failed:", err)
 			}
 			log.Debug("Primary Keepalive Message =>", "ServerWALEnd:",
 				pkm.ServerWALEnd, "ServerTime:",
@@ -112,7 +112,7 @@ func (c *Conn) NextTransactions() (t Transaction, err error) {
 		case pglogrepl.XLogDataByteID:
 			xld, err = pglogrepl.ParseXLogData(msg.Data[1:])
 			if err != nil {
-				log.Fatalln("ParseXLogData failed:", err)
+				log.Fatal("ParseXLogData failed:", err)
 			}
 			log.Debug("XLogData =>", "WALStart",
 				xld.WALStart,

--- a/pkg/rabbitmq/queue.go
+++ b/pkg/rabbitmq/queue.go
@@ -1,7 +1,10 @@
 package rabbitmq
 
 import (
+	"fmt"
 	amqp "github.com/rabbitmq/amqp091-go"
+	"net"
+	"time"
 )
 
 type Queues map[string]*Queue
@@ -15,18 +18,31 @@ type Queue struct {
 }
 
 func (q *Queue) Connect() (err error) {
+	if q.channel != nil {
+		return fmt.Errorf("RabbitMQ channel already initialized")
+	}
 	if q.conn != nil {
 		log.Info("RabbitMQ connection already initialized")
-	} else if q.conn, err = amqp.Dial(q.config.Url); err != nil {
-		return err
+	} else {
+		for {
+			q.conn, err = amqp.Dial(q.config.Url)
+			switch err.(type) {
+			case nil:
+				log.Debug("RabbitMQ connected")
+			case *net.OpError:
+				log.Errorf("RabbitMQ not available: %v", err)
+				log.Infof("Retrying in 10 seconds")
+				time.Sleep(10 * time.Second)
+				continue
+			default:
+				log.Errorf("Unknown error: %v", err)
+				return err
+			}
+			break
+		}
 	}
-	if q.channel != nil {
-		log.Info("RabbitMQ channel already initialized")
-	} else if q.channel, err = q.conn.Channel(); err != nil {
-		return err
-	}
-
-	return nil
+	q.channel, err = q.conn.Channel()
+	return err
 }
 
 func (q *Queue) MustClose() {


### PR DESCRIPTION
- Pushing to docker try 4
- Pushing to docker try 5
- using docker-compose-tests with binaries from github or images from docker-hub
- Cleanup of some unused configuration
- standbyMessageTimeout already is time.Duration
- prefix improved and also for queues
- No need for requiring replication=
- DSN as string with masked option
- minor tweaks to docker-compose-tests.sh: - wait for postgres to start - bitnami/kafka only amd64 - don't do the .s
- Add build_image to Makefile for easier development
- New docs
- Working on TLDR
- Minor tweak in docker-compose-tests.sh
- using zookeeper seems to work better
- Adding CLoseWriter
- Renaming topic.parent to topic.config
- Making kafka connection a bit more resilient.
- minor, but moving to log.Fatal because log.Fatalln expects only a single line, not 2 arguments
- Finished docker build command
- Unwrapping errrors and retry option for kafkaarrowpg
- standbyMessageTimeout was not exposed as config, and added option for SkipErrors on PG SQLSTATE
